### PR TITLE
Fix name function for downloading non OPM repositories

### DIFF
--- a/lpm
+++ b/lpm
@@ -102,7 +102,7 @@ def performDirectDownload(lpm, name, url, dltype, branch, packages, logger):
     if download is None:
         print(f"download method {dltype} unkown")
         return False
-    return lpm.feetchFromDownloader(name, download, 0, packages)
+    return lpm.fetchFromDownloader(name, download, 0, packages)
 
 def handleLazarus(lpm, action, name, path):
     if action == "add":


### PR DESCRIPTION
The function to download non OPM repositories is badly typed. Change the call function to download non OPM repositories.

# Fix

```Python
Traceback (most recent call last):
  File "/usr/bin/lpm", line 244, in <module>
    main()
  File "/usr/bin/lpm", line 230, in main
    success = performDirectDownload(lpm, args.name, args.url, args.type, args.branch, args.packages, logger)
  File "/usr/bin/lpm", line 105, in performDirectDownload
    return lpm.feetchFromDownloader(name, download, 0, packages)
AttributeError: 'PackageManager' object has no attribute 'feetchFromDownloader'
```
